### PR TITLE
adds missing dep to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         'python-dotenv==0.19.1',
+        'httpx==0.22.0',
     ],
     include_package_data=True,
     package_data={


### PR DESCRIPTION
## Summary

Setup.py was missing `httpx` as a dependency for the common lib to work properly. 

## JIRA Issues

N/A

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)


## Testing

Are there any new or updated tests to validate the changes?


- [x] No

## Test Directions

Will need to be successfully installed in another service. 
